### PR TITLE
added instructions on extracting firmware

### DIFF
--- a/payloads/README.md
+++ b/payloads/README.md
@@ -16,3 +16,6 @@ There are two variants.
 | Latitude 7370  | 0x071B   | 16          |
 | XPS 9360       | 0x075B   | 21          |
 | XPS 9360       | 0x082A   | 21          |
+
+Payloads can be extracted from the windows firmware updater
+via `7z e $NVM_FW_UPDATER.exe`.


### PR DESCRIPTION
I also checked the firmware available for my system, and found that despite being released on Nov 2 2017,  the binary was built on June 28 and is identical to the one currently in the repo.

This other binaries are also up to date.